### PR TITLE
add map and press location

### DIFF
--- a/src/components/LocationPicker/index.tsx
+++ b/src/components/LocationPicker/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { StyleSheet, View, Text, Alert, Image } from 'react-native';
 import { getMapPreview } from '@/utilities/location';
 import OutlinedButton from '../UI/OutlinedButton';
@@ -8,13 +8,31 @@ import {
 	useForegroundPermissions,
 	PermissionStatus,
 } from 'expo-location';
-import { useNavigation } from '@react-navigation/native';
+import {
+	useNavigation,
+	useRoute,
+	useIsFocused,
+} from '@react-navigation/native';
 import { Map } from '@/screens';
+import { AddPlaceRouteProps } from '@/types';
 
 const LocationPicker = () => {
+	const isFocused = useIsFocused();
 	const nav = useNavigation();
+	const route = useRoute();
 	const [location, setLocation] = useState(null);
 	const [locStatus, requestLocPermission] = useForegroundPermissions();
+
+	useEffect(() => {
+		console.log('isFocused', isFocused);
+		if (isFocused && route.params) {
+			const mapPickedLocation = {
+				lat: route.params.pickedLat,
+				lng: route.params.pickedLng,
+			};
+			setLocation(mapPickedLocation);
+		}
+	}, [route, isFocused]);
 
 	const verifyPermissions = async () => {
 		if (locStatus.status === PermissionStatus.UNDETERMINED) {

--- a/src/components/PlaceForm/index.tsx
+++ b/src/components/PlaceForm/index.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, ScrollView, TextInput, Text, View } from 'react-native';
 import { Colors } from '@/constants/colors';
 import ImagePicker from '../ImagePicker';
 import LocationPicker from '../LocationPicker';
+import Button from '../UI/Button';
 
 const PlaceForm = () => {
 	const [enteredTitle, setEnteredTitle] = useState('');
@@ -10,6 +11,11 @@ const PlaceForm = () => {
 	const changeTitleHandler = (enteredText) => {
 		setEnteredTitle(enteredText);
 	};
+
+	const SavePlaceHandler = () => {
+		console.log('SavePlaceHandler');
+	};
+
 	return (
 		<ScrollView style={styles.form}>
 			<View>
@@ -20,8 +26,9 @@ const PlaceForm = () => {
 					value={enteredTitle}
 				/>
 			</View>
-			<ImagePicker />
-			<LocationPicker />
+			<ImagePicker onImageTaken={} />
+			<LocationPicker onLocationChosen={} />
+			<Button onPress={SavePlaceHandler}>Add Place</Button>
 		</ScrollView>
 	);
 };

--- a/src/components/UI/Button/index.tsx
+++ b/src/components/UI/Button/index.tsx
@@ -1,0 +1,43 @@
+import { StyleSheet, Pressable, Text } from 'react-native';
+import { Colors } from '@/constants/colors';
+
+interface ButtonProps {
+	onPress: () => void;
+	children: React.ReactNode;
+}
+
+const Button = ({ onPress, children }: ButtonProps) => {
+	return (
+		<Pressable
+			onPress={onPress}
+			style={({ pressed }) => [styles.button, pressed && styles.pressed]}
+		>
+			<Text style={styles.text}>{children}</Text>
+		</Pressable>
+	);
+};
+
+export default Button;
+
+const styles = StyleSheet.create({
+	button: {
+		paddingHorizontal: 12,
+		paddingVertical: 8,
+		margin: 4,
+		elevation: 2,
+		shadowColor: 'black',
+		shadowOpacity: 0.15,
+		shadowOffset: { width: 1, height: 1 },
+		shadowRadius: 2,
+		borderRadius: 4,
+		backgroundColor: Colors.primary800,
+	},
+	pressed: {
+		opacity: 0.5,
+	},
+	text: {
+		textAlign: 'center',
+		fontSize: 16,
+		color: Colors.primary50,
+	},
+});

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,7 +1,8 @@
 export { default as PlacesList } from './PlacesList';
 export { default as PlaceItem } from './PlaceItem';
 export { default as PlaceForm } from './PlaceForm';
-export { default as IconButton } from './UI/IconButton';
 export { default as ImagePicker } from './ImagePicker';
-export { default as OutlinedButton } from './UI/OutlinedButton';
 export { default as LocationPicker } from './LocationPicker';
+export { default as IconButton } from './UI/IconButton';
+export { default as Button } from './UI/Button';
+export { default as OutlinedButton } from './UI/OutlinedButton';

--- a/src/screens/Map/index.tsx
+++ b/src/screens/Map/index.tsx
@@ -1,14 +1,77 @@
-import MapView, { Marker } from 'react-native-maps';
+import { useLayoutEffect, useState, useCallback } from 'react';
+import { Alert } from 'react-native';
+import MapView, {
+	Marker,
+	MapPressEvent,
+	MapMarkerProps,
+} from 'react-native-maps';
+import { IconButton } from '@/components';
 import { styles } from './mapStyle';
 
-const Map = () => {
+const Map = ({ navigation }) => {
+	const [selectedLocation, setSelectedLocation] = useState<{
+		lat: number;
+		lng: number;
+	}>();
+
 	const region = {
 		latitude: 37.78,
 		longitude: -122.43,
 		latitudeDelta: 0.0922,
 		longitudeDelta: 0.0421,
 	};
-	return <MapView initialRegion={region} style={styles.map} />;
+
+	const selectLocationHandler = (event: MapPressEvent) => {
+		const lat = event.nativeEvent.coordinate.latitude;
+		const lng = event.nativeEvent.coordinate.longitude;
+		setSelectedLocation({ lat, lng });
+	};
+
+	const savePickedLocationHandler = useCallback(() => {
+		if (!selectedLocation) {
+			Alert.alert(
+				'No location picked',
+				'You must pick a location by tapping on the map.'
+			);
+			return;
+		}
+		navigation.navigate('AddPlace', {
+			pickedLat: selectedLocation.lat,
+			pickedLng: selectedLocation.lng,
+		});
+	}, [navigation, selectedLocation]);
+
+	useLayoutEffect(() => {
+		navigation.setOptions({
+			headerRight: ({ tintColor }) => (
+				<IconButton
+					icon='save'
+					size={24}
+					color={tintColor}
+					onPress={() => {
+						savePickedLocationHandler();
+					}}
+				/>
+			),
+		});
+	}, [navigation, savePickedLocationHandler]);
+
+	return (
+		<MapView
+			initialRegion={region}
+			onPress={selectLocationHandler}
+			style={styles.map}
+		>
+			{selectedLocation && (
+				<Marker
+					coordinate={{
+						latitude: selectedLocation.lat,
+						longitude: selectedLocation.lng,
+					}}
+				/>
+			)}
+		</MapView>
+	);
 };
 
 export default Map;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,2 @@
 export { default as Place } from './place';
+export { default as AddPlaceRouteProps } from './routeProps';

--- a/src/types/routeProps.ts
+++ b/src/types/routeProps.ts
@@ -1,0 +1,6 @@
+type AddPlaceProps = {
+	pickedLat: number;
+	pickedLng: number;
+};
+
+export default AddPlaceProps;

--- a/src/utilities/location.ts
+++ b/src/utilities/location.ts
@@ -2,6 +2,5 @@ import { GOOGLE_MAPS_URI, GOOGLE_API_KEY } from '@env';
 
 export const getMapPreview = (lat: number, lng: number) => {
 	const imagePreviewUrl = `${GOOGLE_MAPS_URI}?center=${lat},${lng}&zoom=14&size=400x200&maptype=roadmap&markers=color:red%7Clabel:S%7C${lat},${lng}&key=${GOOGLE_API_KEY}`;
-	console.log('IPU: ', imagePreviewUrl);
 	return imagePreviewUrl;
 };


### PR DESCRIPTION
This PR:
   - adds a map screen to the app
   - allows users to touch the screen to select a location on the map
   - allows navigation back to the main screen and passes in the location data.